### PR TITLE
goのWASMファイルをtinygoで生成するように修正

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -8,6 +8,7 @@ name: Deploy to Firebase Hosting on merge
       - main
 jobs:
   build_and_deploy:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -8,7 +8,6 @@ name: Deploy to Firebase Hosting on merge
       - main
 jobs:
   build_and_deploy:
-    permissions: read-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: acifani/setup-tinygo@v2
       - run: |
-          GOOS=js GOARCH=wasm go build -o public/main.wasm
+          GOOS=js GOARCH=wasm tinygo build -o public/main.wasm
           echo ${{secrets.AD_SENSE_TXT}} > public/ads.txt
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,8 +5,9 @@ name: Deploy to Firebase Hosting on PR
 'on': pull_request
 
 permissions:
-  id-token: read
+  checks: write
   contents: read
+  pull-requests: write
 
 jobs:
   build_and_preview:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -3,12 +3,15 @@
 
 name: Deploy to Firebase Hosting on PR
 'on': pull_request
+
+permissions:
+  id-token: read
+  contents: read
+
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
       - run: GOOS=js GOARCH=wasm go build -o public/main.wasm

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,8 +6,9 @@ name: Deploy to Firebase Hosting on PR
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
-    permissions: read-all
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - run: GOOS=js GOARCH=wasm go build -o public/main.wasm

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,6 +6,7 @@ name: Deploy to Firebase Hosting on PR
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
tinygoでビルドしてみたら結構軽くなって挙動も問題なかったのでこっちに移行する。
tinygoのセットアップには https://github.com/acifani/setup-tinygo を使う。

比較(du -h public/go.wasm public/tinygo.wasm)
2.2M    public/go.wasm
680K    public/tinygo.wasm
